### PR TITLE
fix: render INPUT_CHIPS in InputBar when showChips is true

### DIFF
--- a/src/components/chat/ChatWindow.tsx
+++ b/src/components/chat/ChatWindow.tsx
@@ -208,6 +208,7 @@ export function ChatWindow() {
         onSend={handleSend}
         value={inputValue}
         onChange={setInputValue}
+        showChips={isEmpty}
       />
     </div>
   );

--- a/src/components/chat/InputBar.tsx
+++ b/src/components/chat/InputBar.tsx
@@ -11,7 +11,7 @@ interface InputBarProps {
   showChips?: boolean;
 }
 
-export function InputBar({ isLoading, onSend, value, onChange }: InputBarProps) {
+export function InputBar({ isLoading, onSend, value, onChange, showChips }: InputBarProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const canSend = !isLoading && value.trim().length > 0;
@@ -80,6 +80,23 @@ export function InputBar({ isLoading, onSend, value, onChange }: InputBarProps) 
           )}
         </button>
       </div>
+
+      {/* 제안 칩 */}
+      {showChips && (
+        <div className="flex flex-wrap gap-2 mt-3">
+          {INPUT_CHIPS.map((chip) => (
+            <button
+              key={chip}
+              type="button"
+              onClick={() => onSend(chip)}
+              disabled={isLoading}
+              className="text-xs px-3 py-1.5 rounded-full bg-white border border-gray-200 text-gray-600 hover:border-indigo-300 hover:text-indigo-600 hover:bg-indigo-50 transition-colors shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {chip}
+            </button>
+          ))}
+        </div>
+      )}
 
       {/* 도움말 텍스트 */}
       <p className="text-[11px] text-gray-400 mt-2 px-1">


### PR DESCRIPTION
## Summary

- `InputBar`에서 `showChips` prop이 정의되어 있었지만 destructure되지 않아 완전히 무시되고 있었음
- `INPUT_CHIPS`도 import만 되고 렌더링 코드가 없었음
- 첫 화면(메시지 없을 때)에만 칩이 표시되도록 `ChatWindow`에서 `showChips={isEmpty}` 전달

## Changes

**`InputBar.tsx`**
- `showChips` prop을 destructure에 포함
- `showChips`가 `true`일 때 `INPUT_CHIPS` 목록을 pill 버튼으로 렌더링
- 각 칩 클릭 시 `onSend(chip)` 직접 호출 (입력창 거치지 않음)
- `isLoading` 중에는 칩 비활성화 (`disabled` + opacity)

**`ChatWindow.tsx`**
- `<InputBar showChips={isEmpty} />`로 prop 전달

## Test plan

- [ ] 메시지가 없는 첫 화면에서 입력창 아래 제안 칩 4개가 표시되는지 확인
- [ ] 칩 클릭 시 해당 텍스트가 바로 전송되는지 확인
- [ ] 첫 메시지 전송 후 칩이 사라지는지 확인 (`isEmpty === false`)
- [ ] `isLoading` 중 칩이 비활성화되는지 확인

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)